### PR TITLE
fuse: use safe go_marshal API for FUSE

### DIFF
--- a/pkg/sentry/fsimpl/fuse/connection.go
+++ b/pkg/sentry/fsimpl/fuse/connection.go
@@ -270,8 +270,10 @@ func (conn *connection) NewRequest(creds *auth.Credentials, pid uint32, ino uint
 	}
 
 	buf := make([]byte, hdr.Len)
-	hdr.MarshalUnsafe(buf[:hdrLen])
-	payload.MarshalUnsafe(buf[hdrLen:])
+
+	// TODO(gVisor.dev/3698): Use the unsafe version once go_marshal is safe to use again.
+	hdr.MarshalBytes(buf[:hdrLen])
+	payload.MarshalBytes(buf[hdrLen:])
 
 	return &Request{
 		id:   hdr.Unique,
@@ -359,7 +361,8 @@ func (r *Response) UnmarshalPayload(m marshal.Marshallable) error {
 		return nil
 	}
 
-	m.UnmarshalUnsafe(r.data[hdrLen:])
+	// TODO(gVisor.dev/3698): Use the unsafe version once go_marshal is safe to use again.
+	m.UnmarshalBytes(r.data[hdrLen:])
 	return nil
 }
 

--- a/tools/go_marshal/marshal/marshal_impl_util.go
+++ b/tools/go_marshal/marshal/marshal_impl_util.go
@@ -44,7 +44,7 @@ func (StubMarshallable) MarshalBytes(dst []byte) {
 
 // UnmarshalBytes implements Marshallable.UnmarshalBytes.
 func (StubMarshallable) UnmarshalBytes(src []byte) {
-	panic("Please implement your own UnMarshalBytes function")
+	panic("Please implement your own UnmarshalBytes function")
 }
 
 // Packed implements Marshallable.Packed.


### PR DESCRIPTION
Until #3698 is resolved, this change is needed to ensure we're not
corrupting memory anywhere.

