### PR TITLE
fuse: Fix FUSE_READDIR offset issue

### DIFF
--- a/pkg/sentry/fsimpl/fuse/directory.go
+++ b/pkg/sentry/fsimpl/fuse/directory.go
@@ -87,7 +87,7 @@ func (dir *directoryFD) IterDirents(ctx context.Context, callback vfs.IterDirent
 	}
 
 	for _, fuseDirent := range out.Dirents {
-		nextOff := int64(fuseDirent.Meta.Off) + 1
+		nextOff := int64(fuseDirent.Meta.Off)
 		dirent := vfs.Dirent{
 			Name:    fuseDirent.Name,
 			Type:    uint8(fuseDirent.Meta.Type),


### PR DESCRIPTION
According to [readdir(3)](https://linux.die.net/man/3/readdir), the offset attribute in struct dirent is the offset to the next dirent instead of the offset of itself. Send the successive FUSE_READDIR requests with the offset retrieved from the last entry.
