### PR TITLE
fuse: Fix path resolving fails by implementing inode.Getlink

### DIFF
--- a/pkg/sentry/fsimpl/fuse/fusefs.go
+++ b/pkg/sentry/fsimpl/fuse/fusefs.go
@@ -503,6 +503,12 @@ func (i *inode) newEntry(kernelTask *kernel.Task, req *Request, name string, fil
 	return child.VFSDentry(), nil
 }
 
+// Getlink implements Inode.Getlink.
+func (i *inode) Getlink(ctx context.Context, mnt *vfs.Mount) (vfs.VirtualDentry, string, error) {
+	path, err := i.Readlink(ctx, mnt)
+	return vfs.VirtualDentry{}, path, err
+}
+
 // Readlink implements Inode.Readlink.
 func (i *inode) Readlink(ctx context.Context, mnt *vfs.Mount) (string, error) {
 	if i.Mode().FileType()&linux.S_IFLNK == 0 {


### PR DESCRIPTION
[kernfs uses inode.Getlink to resolve symlink](https://github.com/google/gvisor/blob/6405525b046bb82a39e3338e61e41690133c43c1/pkg/sentry/fsimpl/kernfs/filesystem.go#L85) when look up paths.

Updates #3452