### PR TITLE
fuse: Support multiple FUSE kernel versions of FUSE_INIT response struct

### DIFF
--- a/pkg/sentry/fsimpl/fuse/connection.go
+++ b/pkg/sentry/fsimpl/fuse/connection.go
@@ -345,6 +345,11 @@ func (r *Response) Error() error {
 	return error(sysErrNo)
 }
 
+// DataLen returns the size of the response without the header.
+func (r *Response) DataLen() uint32 {
+	return r.hdr.Len - uint32(r.hdr.SizeBytes())
+}
+
 // UnmarshalPayload unmarshals the response data into m.
 func (r *Response) UnmarshalPayload(m marshal.Marshallable) error {
 	hdrLen := r.hdr.SizeBytes()

--- a/pkg/sentry/fsimpl/fuse/init.go
+++ b/pkg/sentry/fsimpl/fuse/init.go
@@ -75,12 +75,12 @@ func (conn *connection) InitRecv(res *Response, hasSysAdminCap bool) error {
 		return err
 	}
 
-	var out linux.FUSEInitOut
-	if err := res.UnmarshalPayload(&out); err != nil {
+	initRes := linux.FUSEInitRes{Len: res.DataLen()}
+	if err := res.UnmarshalPayload(&initRes); err != nil {
 		return err
 	}
 
-	return conn.initProcessReply(&out, hasSysAdminCap)
+	return conn.initProcessReply(&initRes.InitOut, hasSysAdminCap)
 }
 
 // Process the FUSE_INIT reply from the FUSE server.


### PR DESCRIPTION
The `fuse_init_out` struct changes in different FUSE kernel versions. A FUSE server may implement older versions of `fuse_init_out`, but they share common attributes from the beginning. Implement variable-length marshallable interface to support older versions of ABI.